### PR TITLE
typo for vsync option (number 3 missing for drop)

### DIFF
--- a/doc/ffmpeg.texi
+++ b/doc/ffmpeg.texi
@@ -978,7 +978,7 @@ constant frame rate.
 @item 2, vfr
 Frames are passed through with their timestamp or dropped so as to
 prevent 2 frames from having the same timestamp.
-@item drop
+@item 3, drop
 As passthrough but destroys all timestamps, making the muxer generate
 fresh timestamps based on frame-rate.
 @item -1, auto


### PR DESCRIPTION
vsync option expects a number. For "drop" case, we need to provide the number 3 but the typo in the doc will make people think they need to type "drop" instead.
